### PR TITLE
Add implementation in vimscript.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ make
 ./main
 ```
 
+Or for the vimscript implementation:
+
+```sh
+vim --cmd ":source vimos.vim"
+```
+
 ---
 
 This project is a joke on the common statement "Emacs is a great operating system, too bad it doesn't have a decent text editor." Please do not take it seriously.

--- a/vimos.vim
+++ b/vimos.vim
@@ -1,0 +1,1 @@
+:call job_start("kill -ILL " . getpid())


### PR DESCRIPTION
A project like this is too important to trust to a flash-in-the-pan language like Rust. Rust has only been around since 2015! Vimscript is so old I can't work out exactly how old it is.

And let's face it: when the programmer-archaeologists a million years from now are digging through their systems, trying to find the root cause of some obscure bug that's been plagueing them for the last three hundred light years, you just know it's going to bottom out in vimscript. There's no other way things can go.

This was surprisingly subtle to implement. It seems that vim [ignores most signals when it's busy][1], and `:system(...)` and `:execute !...` both leave it busy until the command finishes. So we'd be able to use them with `-9`, but that wouldn't reimplement the rust, which raises SIGILL. So we use `job_start`, which doesn't wait for the job to finish; and we don't subsequently quit, because that would happen before the signal is caught.

Output:

    $ vim --cmd ":source vimos.vim"
    Vim: Caught deadly signal ILL
    Vim: Finished.
    zsh: illegal hardware instruction (core dumped)  vim --cmd ":source vimos.vim"

[1]: https://vi.stackexchange.com/questions/29636/why-is-it-not-possible-to-kill-vim-using-the-term-signal-from-inside-vim-itself